### PR TITLE
fix: return a list of TaskOutput rather than just the output

### DIFF
--- a/semaphoreui_client/client.py
+++ b/semaphoreui_client/client.py
@@ -534,12 +534,14 @@ class SemaphoreUIClient:
         )
         assert response.status_code == 204
 
-    def get_project_task_output(self, project_id: int, id: int) -> "TaskOutput":
+    def get_project_task_output(
+        self, project_id: int, id: int
+    ) -> typing.List["TaskOutput"]:
         response = self.http.get(
             f"{self.api_endpoint}/project/{project_id}/tasks/{id}/output"
         )
         assert response.status_code == 200
-        return TaskOutput(**response.json())
+        return [TaskOutput(**data) for data in response.json()]
 
 
 @dataclass
@@ -980,12 +982,16 @@ class Task:
     def delete(self) -> None:
         self.client.delete_project_task(self.project_id, self.id)
 
-    def output(self) -> "TaskOutput":
+    def output(self) -> typing.List["TaskOutput"]:
         return self.client.get_project_task_output(self.project_id, self.id)
+
+    def normalized_output(self) -> typing.List[str]:
+        return [output.output for output in self.output()]
 
 
 @dataclass
 class TaskOutput:
     task_id: int
+    task: str
     time: str
     output: str


### PR DESCRIPTION
This patch changes `Task.output` to return a list of `TaskOutput`, as well as adds a `Task.normalized_output` that returns a list of strings representing the output.