### PR TITLE
fix: make Task.output a list of strings

### DIFF
--- a/semaphoreui_client/client.py
+++ b/semaphoreui_client/client.py
@@ -565,12 +565,12 @@ class SemaphoreUIClient:
         )
         assert response.status_code == 204
 
-    def get_project_task_output(self, project_id: int, id: int) -> str:
+    def get_project_task_output(self, project_id: int, id: int) -> typing.List[str]:
         response = self.http.get(
             f"{self.api_endpoint}/project/{project_id}/tasks/{id}/output"
         )
         assert response.status_code == 200
-        return "\n".join(data["output"] for data in response.json())
+        return [data["output"] for data in response.json()]
 
 
 @dataclass
@@ -1043,5 +1043,5 @@ class Task:
     def delete(self) -> None:
         self.client.delete_project_task(self.project_id, self.id)
 
-    def output(self) -> str:
+    def output(self) -> typing.List[str]:
         return self.client.get_project_task_output(self.project_id, self.id)


### PR DESCRIPTION
This patch changes `Task.output` to be a list of strings. The reason for this change is that it makes it easier to parse lines of output that have json that includes `\n` in it--`splitlines` doesn't handle those correctly.