### PR TITLE
fix: specify force in Task.stop

### DIFF
--- a/semaphoreui_client/client.py
+++ b/semaphoreui_client/client.py
@@ -847,8 +847,8 @@ class Task:
     def url(self) -> str:
         return f"{self.client.api_endpoint}/project/{self.project_id}/tasks/{self.id}"
 
-    def stop(self) -> None:
-        response = self.client.http.post(f"{self.url}/stop")
+    def stop(self, force: bool = False) -> None:
+        response = self.client.http.post(f"{self.url}/stop", json={"force": force})
         assert response.status_code == 204
 
     def delete(self) -> None:


### PR DESCRIPTION
This patch adds the `force` parameter to `Task.stop`, which is required by the api, but is not documented.